### PR TITLE
Documentation + standalone executable (compiletime)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.swp
+*.hi
+*.o
+
+weechat-log-to-html

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.o
 
 weechat-log-to-html
+*.mod.hs

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,29 @@
+HS = ghc
+HS_FLAGS = -O
+TARGET = weechat-log-to-html
+SRC = weechat-log-to-html.mod.hs
+
+HTML_HEAD = head.html
+
+###############################################################################
+
+all: $(TARGET)
+
+$(TARGET): $(SRC)
+	$(HS) --make -o $@ $(SRC)
+
+%.mod.hs: %.hs $(HTML_HEAD)
+	cutline=$$(grep -nm 1 -- "-- INSERT FROM HERE" $< | cut -f1 -d:) ;\
+		head -n $$(expr $$cutline - 1) $< > $@
+	echo "header = unlines [" >> $@
+	cat $(HTML_HEAD) | sed -e 's/"/\\"/g' -e 's/^/    "/g' -e 's/$$/",/g' >> $@
+	echo '    ""]' >> $@
+	cutlineEnd=$$(grep -nm 1 -- "-- INSERT TO HERE" $< | cut -f1 -d:) ;\
+		tail --lines=+$$(expr $$cutlineEnd + 1) $< >> $@
+
+
+clean:
+	rm -f *.o *.hi *.mod.hs
+
+cleanall: clean
+	rm -f $(TARGET)

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
-A script to turn Weechat logs into nicely formatted HTML.
-Should work both with the contents of the .weechat/logs directory and the output of bufsave.py.
+# Weechat-log-to-html
 
+A script to turn Weechat logs into nicely formatted HTML.
+Should work both with the contents of the `.weechat/logs` directory and the output of `bufsave.py`.
+
+## Compile
+
+You can use any Haskell compiler to compile this, eg. `ghc`.
+
+## Usage
+
+```Bash
+./weechat-log-to-html < somelog.weechatlog > somelog.html
+```
+
+## Features
+
+This script generates a clean HTML file from a Weechat log file, handling nicknames coloring, …

--- a/README.md
+++ b/README.md
@@ -5,7 +5,13 @@ Should work both with the contents of the `.weechat/logs` directory and the outp
 
 ## Compile
 
-You can use any Haskell compiler to compile this, eg. `ghc`.
+Run
+
+```Bash
+make
+```
+to compile this script. Beware! This Makefile does non-standard things, and
+does not simply call `ghc --make`!
 
 ## Usage
 

--- a/weechat-log-to-html.hs
+++ b/weechat-log-to-html.hs
@@ -11,6 +11,15 @@ data WeechatLine = WeechatLine { wlDate :: String
                                , wlMsg :: String }
 -- TODO: specific handling of join/part/network messages
 
+-- INSERT FROM HERE
+-- ^ the compilation process requires the presence of this comment line.
+-- This part will be ERASED before compilation, and replaced by the actual
+-- template
+header = ""
+-- v this line is required as well
+-- INSERT TO HERE
+
+
 main = (printHTML . parseWeechatLog) =<< getContents
 
 parseWeechatLog :: String -> [WeechatLine]
@@ -21,8 +30,7 @@ parseWeechatLog = map parseWeechatLine . lines
           in WeechatLine date time nick msg
 
 printHTML :: [WeechatLine] -> IO ()
-printHTML log = do header <- readFile "head.html"
-                   putStrLn header
+printHTML log = do putStrLn header
                    putStrLn "<body>"
                    mapM_ printDay days
                    putStrLn "</body>"
@@ -37,7 +45,8 @@ printHTML log = do header <- readFile "head.html"
         printRow (prevRow, curRow) = do
           putStr $ "<tr><td>" ++ wlTime curRow ++ "</td>"
           putStr $ "<td class=\"" ++ ac ++ "\">" ++ nick ++ "</td>"
-          putStrLn $ "<td>" ++ (colorhl allNicks . escape $ wlMsg curRow) ++ "</td></tr>"
+          putStrLn $ "<td>" ++ (colorhl allNicks . escape $ wlMsg curRow)
+                   ++ "</td></tr>"
           where prevNick = wlNick prevRow
                 curNick = wlNick curRow
                 nick | specialNick curNick = curNick
@@ -63,7 +72,8 @@ colors = ["cyan","magenta","green","brown","lightblue","default",
 colorhl allNicks msg
   | firstWord == "" = msg
   | last firstWord == ':' && nick `Set.member` allNicks =
-      sigils ++ "<span class=\"nc-color-" ++ hash nick ++ "\">" ++ nick ++ "</span>:" ++ rest
+      sigils ++ "<span class=\"nc-color-" ++ hash nick ++ "\">" ++ nick
+             ++ "</span>:" ++ rest
   | otherwise = msg
   where (firstWord, rest) = span (not . isSpace) msg
         (sigils, nick') = span sigil firstWord
@@ -73,5 +83,3 @@ escape = concat . map entity
   where entity '<' = "&lt;"
         entity '>' = "&gt;"
         entity c = [c]
-  
-


### PR DESCRIPTION
Documents a bit more the script.
Makes the executable produced by compilation (`make`) standalone, ie. with no need for `head.html` to be in the _working directory_ (which was a bit painful to handle). This is achieved through a custom compilation process, generating an intermediary source file in which `head.html` is inlined.
Please merge either this PR or #1.
