### PR TITLE
Updated nick coloring, added metadata/synopsis section for each log, cleaned up HTML

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,5 @@
-Copyright (c) 2015-2017 NGUYEN Le Thanh Dung.
+Copyright (c) 2015-2021 NGUYEN Le Thanh Dung, Théophile Bastian, anelki and
+other contributors
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # weechat-log-to-html
 
---
-
 A script to turn Weechat logs into nicely formatted HTML. Should work both with the contents of the `.weechat/logs` directory and the output of `bufsave.py`.
 
 ## Compile

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # weechat-log-to-html
 
+## Ongoing Development/PRs etc.
+
+For PRs/Issues et please see the project's main repository at: [hg.sr.ht~anelki/weechat-log-html](https://hg.sr.ht/~anelki/weechat-log-html)
+
+---
+
 A script to turn Weechat logs into nicely formatted HTML. Should work both with the contents of the `.weechat/logs` directory and the output of `bufsave.py`.
 
 ## Compile

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
-# Weechat-log-to-html
+# weechat-log-to-html
 
-A script to turn Weechat logs into nicely formatted HTML.
-Should work both with the contents of the `.weechat/logs` directory and the output of `bufsave.py`.
+--
+
+A script to turn Weechat logs into nicely formatted HTML. Should work both with the contents of the `.weechat/logs` directory and the output of `bufsave.py`.
 
 ## Compile
 
@@ -9,10 +10,47 @@ You can use any Haskell compiler to compile this, eg. `ghc`.
 
 ## Usage
 
-```Bash
+```sh
 ./weechat-log-to-html < somelog.weechatlog > somelog.html
 ```
 
 ## Features
 
-This script generates a clean HTML file from a Weechat log file, handling nicknames coloring, …
+This script generates a clean HTML file from a Weechat log file.
+
+### v1.3
+* further HTML cleanup, somewhat improved styling and tweaks to the color palette.
+
+
+### v1.2
+* edited the way HTML `<meta>` tags are written
+
+
+### v1.1
+* now inserts log metadata html ("title", "players", etc.) so you only need to edit the values in each field.
+* minor fixes here and there
+
+### v1.0
+* made html output responsive for mobile devices
+* edits to nick colors
+
+**Full commit log can be found on [hg.sr.ht](https://hg.sr.ht/~anelki/weechat-log-html)**
+
+## To-do
+
+* use Haskell text instead of linked lists of characters
+* provide a way to use logs from rooms that are bridged, eg., via [Matterbridge](https://github.com/42wim/matterbridge)
+
+Matterbridge support is important because as logs will just show up as the bridge user. In this example, the bridge user's nick is 'matterbridge:'
+
+```
+2021-08-05 08:33:28     matterbridge    <xmpp user> I love XMPP and selfhosting is easy
+2021-08-05 08:37:41     matterbridge    <matrix user> nah, Matrix is so secure and flawless
+2021-08-05 08:41:04     IRC User	maybe i'm just oldschool, but IRC is still where it's at!
+```
+
+As it is now, this tool will attribute all of the bridged users as a single user, making a log harder to grok. Patches to fix this would be welcome.
+
+## License
+See LICENSE.txt
+

--- a/weechat-log-to-html.hs
+++ b/weechat-log-to-html.hs
@@ -1,25 +1,27 @@
+-- weechat-log-to html
+-- just run `ghc weechat-log-to-html.hs` and you're good.
+-- for licensing information see 'LICENSE.txt'
+
 import Data.Char
 import Data.Function
 import Data.List
 import qualified Data.Set as Set
--- TODO: use Text instead of linked lists of chars
 
 type WeechatLog = [WeechatLine]
 data WeechatLine = WeechatLine { wlDate :: String
                                , wlTime :: String
                                , wlNick :: String
                                , wlMsg :: String }
--- TODO: specific handling of join/part/network messages
-
 header = unlines [
     "<!DOCTYPE html>",
     "<html>",
     "  <head>",
-    "    <meta charset=\"UTF-8\" />",
+    "    <meta charset=\"UTF-8\">",
+    "    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">",
     "    <title>IRC log</title>",
     "    <style media=\"screen\" type=\"text/css\">",
     "      body {",
-    "        font-family: monospace;",
+    "        font-family: 'Roboto Mono', monospace, sans-serif;",
     "      }",
     "      tr:nth-child(2n+1) {",
     "        background-color: #dddddd;",
@@ -45,7 +47,7 @@ header = unlines [
     "        color: darkgreen;",
     "      }",
     "      .nc-color-3 {",
-    "        color: brown;",
+    "        color: darkred;",
     "      }",
     "      .nc-color-4 {",
     "        color: blue;",
@@ -53,19 +55,31 @@ header = unlines [
     "      .nc-color-5 {",
     "      }",
     "      .nc-color-6 {",
-    "        color: mediumturquoise;",
+    "        color: steelblue;",
     "      }",
     "      .nc-color-7 {",
-    "        color: magenta;",
+    "        color: rebeccapurple;",
     "      }",
     "      .nc-color-8 {",
-    "        color: limegreen;",
+    "        color: royalblue;",
     "      }",
     "      .nc-color-9 {",
-    "        color: darkblue;",
+    "        color: darkslateblue;",
     "      }",
     "    </style>",
-    "  </head>" ]
+    "  </head>",
+    "  <body>",
+    "  <h2>TITLE GOES HERE, YOU FOOL</h2>",
+    "  <ul>",
+    "    <li>channel: #meta</li>",
+    "    <li>synopsis: foo bar baz *eyeroll*</li>",
+    "    <li>the players</li>",
+    "    <ul>",
+    "      <li>antagonists: fool </li>",
+    "      <li>chaotic stupid: damned fool</li>",
+    "      <li>protagonists: heroes</li>",
+    "    </ul>",
+    "  </ul>" ]
 
 main = (printHTML . parseWeechatLog) =<< getContents
 
@@ -78,7 +92,6 @@ parseWeechatLog = map parseWeechatLine . lines
 
 printHTML :: [WeechatLine] -> IO ()
 printHTML log = do putStrLn header
-                   putStrLn "<body>"
                    mapM_ printDay days
                    putStrLn "</body>"
                    putStrLn "</html>"
@@ -113,8 +126,8 @@ sigil = (`elem` "@%+")
 -- Weechat default nick hash function = sum of unicode values
 hash = show . (`mod` (length colors)) . sum . map ord
 
-colors = ["cyan","magenta","green","brown","lightblue","default",
-          "lightcyan","lightmagenta","lightgreen","blue"]
+colors = ["darkmagenta","darkgreen","darkred","blue","default",
+          "steelblue","rebeccapurple","royalblue","darkslateblue"]
 
 colorhl allNicks msg
   | firstWord == "" = msg

--- a/weechat-log-to-html.hs
+++ b/weechat-log-to-html.hs
@@ -36,7 +36,6 @@ header = unlines [
     "      table {",
     "        border-collapse: collapse;",
     "      }",
-    "",
     "      .nc-color-0 {",
     "        color: darkcyan;",
     "      }",


### PR DESCRIPTION
Have been fidling with this on a Mercurial [repo](https://hg.sr.ht/~anelki/weechat-log-html) and wanted to offer it to you as a PR. 

I've added the following:

* Nick colors are easier to read
* added beginning section for a summary of the log/channel/etc.
* cleaned up HTML and made the page use responsive design by default

no worries if you're not interested but I wanted to offer it. Thanks for writing it in the first place!